### PR TITLE
Remove default headers for DELETE fixes #170

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -137,7 +137,7 @@ module.exports = function (_) {
         put: jsonType,
         post: jsonType,
         patch: jsonType,
-        delete: jsonType,
+        delete: {},
         common: {'Accept': 'application/json, text/plain, */*'},
         custom: {'X-Requested-With': 'XMLHttpRequest'}
     };


### PR DESCRIPTION
Many webserver do not accept any content on a DELETE request. So the headers should be empty.